### PR TITLE
Added tag option to make importing into Hydrus Network easier

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -17,10 +17,10 @@ Example:
 
 ## folder_name (required)
 
-The name of the folder where the picture will be downloaded.
+The name of the folder where the images will be downloaded.
 
 Example:
-- `"folder_name": "cat_pictures" `
+- `"folder_name": "cat_images" `
 
 
 ## imageboard (optional)
@@ -75,9 +75,20 @@ Example:
 - `"height": ">1024" `
 - `"height": "=1080" `
 
+## tag (optional)
+This option was designed to easily import images downloaded from 4scanner into [Hydrus Network](hydrusnetwork.github.io/hydrus/).
+
+When the `tag` option is set it will create a text file for each image downloaded.
+
+In the Hydrus files import dialog you need to go to `add tags based on filename` then check the `try to load tags from neighbouring .txt files` box.
+
+Example:
+- `["mytag"]`
+- `["hyrule", "character:link", "game:zelda"]`
+
 ## check_duplicate (optional)
 
-Can be true or false. If true, 4scanner will check if the picture already exist in the download directory and won't download it. If false no attempt will be made to not download duplicate pictures.
+Can be true or false. If true, 4scanner will check if the image already exist in the download directory and won't download it. If false no attempt will be made to not download duplicate images.
 
 Default: true
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![4scanner logo](logo/4scanner128.png)
 
-4scanner can search multiple imageboards threads for matching keywords then download all images
-to disk.
+4scanner can search multiple imageboards threads for matching keywords then download all images to disk.
 
 ## Supported imageboards
 - 4chan
@@ -58,9 +57,11 @@ Here is an example of what the JSON file should look like:
 
 ## Search options
 
-4scanner has a lot of options for downloading only the picture you want. Such as downloading only pictures with a certain width or height, or only pictures with a certain extension.
+4scanner has a lot of options for downloading only the images you want. Such as downloading only images with a certain width or height, or only images with a certain extension.
 
 To see all available options with examples check out: [OPTIONS.md](OPTIONS.md)
+
+[Hydrus Network](hydrusnetwork.github.io/hydrus/) users: check out the `tag` [option](OPTIONS.md) to automatically tag your images on import
 
 - Example with all optionals options
 ```json
@@ -73,6 +74,7 @@ To see all available options with examples check out: [OPTIONS.md](OPTIONS.md)
       "height": ">1000",
       "filename": "IMG_",
       "extension": [".jpg", ".png"],
+      "tag": ["game"]
       "keywords": ["tf2", "splatoon", "world of tank"],
       "check_duplicate": true
     }

--- a/bin/4downloader
+++ b/bin/4downloader
@@ -46,13 +46,14 @@ def main():
                         help="Specify width. format: >256, <256 or =256")
     parser.add_argument("-E", "--extension",
                         help="""Download only specific(s) extension(s). Ex: .jpg
-                             (can be multiple extensions separated by a ,)""")
+                             (can be multiple extensions separated by ,)""")
     parser.add_argument("-f", "--filename",
                         help="""Download only images containing the string. Ex: filename_1
                              (can be multiple filenames separated by a ,)""")
     parser.add_argument("-d", "-disable-dupe-check", action='store_true',
                         help="with -d 4scanner will download images even if a duplicate exist in output folder.")
     parser.add_argument("-q", "--quiet", action='store_true', help="quiet")
+    parser.add_argument("-t", "--tag", help="list of tags for importing easily into Hydrus Network, separated by ,")
     parser.add_argument("-o", "--output", help="Specify output folder")
     args = parser.parse_args()
 
@@ -90,7 +91,12 @@ def main():
     else:
         dupe_check = False
 
-    thread_downloader = downloader.downloader(thread_nb, board, chan, output, folder, quiet, condition, dupe_check)
+    if args.tag:
+        tag = args.tag.split(',')
+    else:
+        tag = None
+
+    thread_downloader = downloader.downloader(thread_nb, board, chan, output, folder, quiet, condition, dupe_check, tag)
     thread_downloader.download()
 
 

--- a/scanner/downloader.py
+++ b/scanner/downloader.py
@@ -18,7 +18,7 @@ import shutil
 
 class downloader:
 
-    def __init__(self, thread_nb, board, imageboard, output_folder, folder, is_quiet, condition, check_duplicate):
+    def __init__(self, thread_nb, board, imageboard, output_folder, folder, is_quiet, condition, check_duplicate, tag_list):
         # Getting info about the imageboard URL
         ib_info = imageboard_info.imageboard_info(imageboard)
 
@@ -47,6 +47,7 @@ class downloader:
         self.condition = condition
         self.check_duplicate = check_duplicate
         self.is_quiet = is_quiet
+        self.tag_list = tag_list
 
         # Creating the tmp and output directory
         self.create_dir(self.tmp_dir)
@@ -78,8 +79,10 @@ class downloader:
                                 # If picture is not a duplicate copy it to out_dir
                                 if not self.remove_if_duplicate(tmp_pic):
                                     shutil.move(tmp_pic, final_pic)
+                                    self.add_tag_file(final_pic + ".txt")
                             else:
                                 shutil.move(tmp_pic, final_pic)
+                                self.add_tag_file(final_pic + ".txt")
 
                             time.sleep(2)
 
@@ -96,8 +99,10 @@ class downloader:
                                     # If picture is not a duplicate copy it to out_dir
                                     if not self.remove_if_duplicate(tmp_pic):
                                         shutil.move(tmp_pic, final_pic)
+                                        self.add_tag_file(final_pic + ".txt")
                                 else:
                                     shutil.move(tmp_pic, final_pic)
+                                    self.add_tag_file(final_pic + ".txt")
 
 
                                 time.sleep(2)
@@ -277,3 +282,9 @@ class downloader:
             return False
 
         return out_pic
+
+    def add_tag_file(self, tag_file):
+        if self.tag_list:
+            with open(tag_file, 'w') as f:
+                for tag in self.tag_list:
+                    f.write(tag + "\n") 

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -43,8 +43,8 @@ def scan_thread(keyword, catalog_json):
     return matched_threads
 
 
-def download_thread(thread_id, chan, board, folder, output, condition, dupe_check):
-    thread_downloader = downloader.downloader(thread_id, board,chan, output, folder, True, condition, dupe_check)
+def download_thread(thread_id, chan, board, folder, output, condition, dupe_check, tag_list):
+    thread_downloader = downloader.downloader(thread_id, board,chan, output, folder, True, condition, dupe_check, tag_list)
     t = threading.Thread(target=thread_downloader.download)
     t.daemon = True
     t.start()
@@ -127,13 +127,21 @@ def get_condition(search):
 def get_imageboard(search):
     if 'imageboard' in search:
         chan = search["imageboard"]
-        # will raise error if nor supported
+        # will raise error if not supported
         imageboard_info.imageboard_info(chan)
     else:
         # default
         chan = "4chan"
 
     return chan
+
+def get_tag_list(search):
+    if 'tag' in search:
+        tag = search["tag"]
+    else:
+        tag = None
+
+    return tag
 
 
 def get_keyword(search):
@@ -174,6 +182,8 @@ def scan(keywords_file, output, quota_mb, wait_time):
             dupe_check = get_check_duplicate(search)
             # Getting output folder name
             folder_name = search["folder_name"]
+            # Get tag list (if any)
+            tag_list = get_tag_list(search)
             board = search["board"]
             keywords = get_keyword(search)
 
@@ -186,9 +196,9 @@ def scan(keywords_file, output, quota_mb, wait_time):
                     for thread_id in list(set(threads_id)):
                         if thread_id not in currently_downloading and not was_downloaded(thread_id):
                             download_thread(thread_id, chan, board,
-                                            folder_name,
-                                            output,
-                                            condition, dupe_check)
+                                            folder_name, output,
+                                            condition, dupe_check,
+                                            tag_list)
                         # Used to keep track of what is currently downloading
                         currently_downloading.append(thread_id)
             except urllib.error.HTTPError as err:

--- a/test/test.py
+++ b/test/test.py
@@ -226,7 +226,7 @@ print("Testing download.py")
 
 # Creating download object
 condition = {"ext": False, "filename": False, "width": False, "height": False, }
-download = downloader.downloader(list_of_threads[0], 'a',"4chan", ".", "testci", True, condition, True)
+download = downloader.downloader(list_of_threads[0], 'a',"4chan", ".", "testci", True, condition, True, ["travistag1", "ci:travistag2"])
 
 print("--------------------------------------------------------")
 print("!!! download.load not tested yet !!!                   -")


### PR DESCRIPTION
This option was designed to easily import images downloaded from 4scanner into [Hydrus Network](hydrusnetwork.github.io/hydrus/).

When the `tag` option is set it will create a text file for each image downloaded.

In the Hydrus files import dialog you need to go to `add tags based on filename` then check the `try to load tags from neighbouring .txt files` box.

Tag option examples:
- `["mytag"]`
- `["hyrule", "character:link", "game:zelda"]`