### PR TITLE
Use xdg base directory specification for db

### DIFF
--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -26,8 +26,17 @@ def create_conf_dir():
     """
     Create home config directory
     """
-    if not os.path.isdir(os.path.expanduser("~/.4scanner")):
-        os.mkdir(os.path.expanduser("~/.4scanner"))
+    if os.path.isdir(os.path.expanduser("~/.4scanner")):
+        pass
+    elif os.getenv("XDG_DATA_HOME"):
+        if not os.path.isdir(os.path.join(os.getenv("XDG_DATA_HOME"), "4scanner")):
+            os.mkdir(os.path.join(os.getenv("XDG_DATA_HOME"), "4scanner"))
+    elif os.getenv("APPDATA"):
+        if not os.path.isdir(os.path.join(os.getenv("APPDATA"), "4scanner")):
+            os.mkdir(os.path.join(os.getenv("APPDATA"), "4scanner"))
+    else:
+        if not os.path.isdir(os.path.join(os.getenv("HOME"), ".local", "share", "4scanner")):
+            os.makedirs(os.path.join(os.getenv("HOME"), ".local", "share", "4scanner"))
 
 create_conf_dir()
 db_init()

--- a/scanner/config.py
+++ b/scanner/config.py
@@ -1,7 +1,14 @@
 # Used to store package wide constants
 import os
 
-DB_FILE = os.path.expanduser("~/.4scanner/4scanner.db")
+if os.path.isdir(os.path.expanduser("~/.4scanner")):
+    DB_FILE = os.path.expanduser("~/.4scanner/4scanner.db")
+elif os.getenv("XDG_DATA_HOME"):
+    DB_FILE = os.path.join(os.getenv("XDG_DATA_HOME"), "4scanner", "4scanner.db")
+elif os.getenv("APPDATA"):
+    DB_FILE = os.path.join(os.getenv("APPDATA"), "4scanner", "4scanner.db")
+else:
+    DB_FILE = os.path.join(os.getenv("HOME"), ".local", "share", "4scanner", "4scanner.db")
 
 # Global variable used to keep track of what is downloading
 currently_downloading = []


### PR DESCRIPTION
The database should be stored under $XDG_DATA_HOME if available as specified in https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html. On windows systems the database should be stored under %APPDATA%.